### PR TITLE
Add Docker deployment config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+__pycache__/
+venv/
+tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+# Use PORT env var provided by Render
+CMD ["sh", "-c", "streamlit run ui/app.py --server.port $PORT --server.address 0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ foundational-rag-agent/
 2. Ask questions to the AI agent
 3. View responses with source attribution
 
+## Deployment with Docker on Render
+
+To deploy this application on Render, build the provided `Dockerfile` and set th
+e service command to:
+
+```bash
+streamlit run ui/app.py --server.port $PORT --server.address 0.0.0.0
+```
+
+Render automatically injects the `PORT` environment variable which the
+container uses to expose the Streamlit UI.
+
 ## Dependencies
 
 - Python 3.11+


### PR DESCRIPTION
## Summary
- add Dockerfile for Streamlit deployment
- ignore development files when building Docker image
- document Render deployment steps

## Testing
- `pytest -q` *(fails: KeyError: 'args' in pydantic_ai function_schema)*

------
https://chatgpt.com/codex/tasks/task_b_684c0e713d10832b823ace4058dd91c0